### PR TITLE
become consistent with version numbers in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ See: https://github.com/tektoncd/pipeline for recent version
 2. `kubectl apply -f releases/tekton-pipeline-v0.37.0.yaml`
     
     (Alternative)
-   `kubectl apply -f https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.36.0/release.yaml`
+   `kubectl apply -f https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.37.0/release.yaml`
 
 ### Create Tekton Dashboard in cluster
 See: https://github.com/tektoncd/dashboard for recent version


### PR DESCRIPTION
the last commit bumped releases/tekton-pipeline-v0.37.0.yaml from 0.36.0 to 0.37.0, this PR bumps that in the URL as well